### PR TITLE
Fix the ordering of weighted basis elements

### DIFF
--- a/doc/example.xml
+++ b/doc/example.xml
@@ -242,8 +242,8 @@ MappingByFunction( <group of size 32768 with 15 generators>, <pc group of size\
 gap> Image(t) = W;
 true
 gap> List( AsList( G ), x -> ( x^Embedding( G, KG ) )^t );
-[ <identity> of ..., f2, f1, f3, f7, f1*f2*f3, f2*f3, f2*f7, f1*f3, f1*f7,
-  f3*f7, f1*f2*f7, f1*f2*f3*f7, f2*f3*f7, f1*f3*f7, f1*f2 ]
+[ <identity> of ..., f1, f2, f4, f8, f1*f2, f1*f4, f1*f8, f2*f4, f2*f8, 
+  f4*f8, f1*f2*f4, f1*f2*f8, f1*f4*f8, f2*f4*f8, f1*f2*f4*f8 ]
 ]]>
 </Example>
 
@@ -268,11 +268,10 @@ gap> cc := ConjugacyClasses( W );;
 gap> Length( cc );
 848
 gap> Representative( cc[ Length( cc ) ] );
-f1*f2*f4*f6*f12*f15
+f1*f2*f3*f6*f10*f13
 gap> last^f;
-(Z(2)^0)*<identity> of ...+(Z(2)^0)*f2+(Z(2)^0)*f4+(Z(2)^0)*f1*f2+(Z(2)^
-0)*f1*f3+(Z(2)^0)*f1*f4+(Z(2)^0)*f2*f3+(Z(2)^0)*f2*f4+(Z(2)^0)*f3*f4+(Z(2)^
-0)*f1*f2*f3+(Z(2)^0)*f1*f3*f4
+(Z(2)^0)*<identity> of ...+(Z(2)^0)*f1*f2+(Z(2)^0)*f1*f3+(Z(2)^0)*f1*f4+(Z(2)^
+0)*f2*f3+(Z(2)^0)*f1*f2*f3+(Z(2)^0)*f1*f3*f4
 ]]>
 </Example>
 
@@ -283,11 +282,11 @@ For example, the lower central series can be calculated very quickly.
 <Example>
 <![CDATA[
 gap> LowerCentralSeries( W );
-[ <pc group of size 32768 with 15 generators>,
-  Group([ f3, f5*f8*f10*f12*f13*f14*f15, f6*f8*f12*f14*f15, f7, f9*f12,
-      f10*f14, f11*f13, f13*f14, f14*f15 ]),
-  Group([ f7, f9*f12, f10*f15, f11*f15, f13*f15, f14*f15 ]),
-  Group([ f11*f15, f13*f15, f14*f15 ]), Group([ <identity> of ... ]) ]
+[ <pc group of size 32768 with 15 generators>, 
+  Group([ f4*f8, f5*f7*f11*f13*f15, f6*f7*f9*f11*f13*f14*f15, f8, f9*f13, 
+      f10*f11, f12*f13, f13*f15, f14*f15 ]), 
+  Group([ f8, f9*f15, f10*f11, f12*f15, f13*f15, f14*f15 ]), 
+  Group([ f12*f15, f13*f15, f14*f15 ]), Group([ <identity> of ... ]) ]
 ]]>
 </Example>
 
@@ -302,20 +301,20 @@ result into our group algebra.
 <![CDATA[
 gap> C := Centre( W );;
 gap> m := MinimalGeneratingSet( C );
-[ f7*f13*f14*f15, f13*f14*f15, f7*f11*f14*f15, f15, f3*f5*f14 ]
+[ f8*f13*f14*f15, f13*f14*f15, f8*f12*f14*f15, f15, f4*f6*f8*f13 ]
 gap> List( m, g -> g^f );
 [ (Z(2)^0)*<identity> of ...+(Z(2)^0)*f3+(Z(2)^0)*f1*f2+(Z(2)^0)*f3*f4+(Z(2)^
-    0)*f1*f2*f3+(Z(2)^0)*f1*f2*f4+(Z(2)^0)*f1*f2*f3*f4,
+    0)*f1*f2*f3+(Z(2)^0)*f1*f2*f4+(Z(2)^0)*f1*f2*f3*f4, 
   (Z(2)^0)*f3+(Z(2)^0)*f4+(Z(2)^0)*f1*f2+(Z(2)^0)*f3*f4+(Z(2)^0)*f1*f2*f3+(
     Z(2)^0)*f1*f2*f4+(Z(2)^0)*f1*f2*f3*f4, (Z(2)^0)*<identity> of ...+(Z(2)^
-    0)*f2+(Z(2)^0)*f3+(Z(2)^0)*f1*f2+(Z(2)^0)*f2*f3+(Z(2)^0)*f2*f4+(Z(2)^
-    0)*f3*f4+(Z(2)^0)*f1*f2*f3+(Z(2)^0)*f1*f2*f4+(Z(2)^0)*f2*f3*f4+(Z(2)^
+    0)*f1+(Z(2)^0)*f3+(Z(2)^0)*f1*f2+(Z(2)^0)*f1*f3+(Z(2)^0)*f1*f4+(Z(2)^
+    0)*f3*f4+(Z(2)^0)*f1*f2*f3+(Z(2)^0)*f1*f2*f4+(Z(2)^0)*f1*f3*f4+(Z(2)^
     0)*f1*f2*f3*f4, (Z(2)^0)*f1+(Z(2)^0)*f2+(Z(2)^0)*f3+(Z(2)^0)*f4+(Z(2)^
     0)*f1*f2+(Z(2)^0)*f1*f3+(Z(2)^0)*f1*f4+(Z(2)^0)*f2*f3+(Z(2)^0)*f2*f4+(
     Z(2)^0)*f3*f4+(Z(2)^0)*f1*f2*f3+(Z(2)^0)*f1*f2*f4+(Z(2)^0)*f1*f3*f4+(Z(2)^
-    0)*f2*f3*f4+(Z(2)^0)*f1*f2*f3*f4, (Z(2)^0)*<identity> of ...+(Z(2)^0)*f1+(
-    Z(2)^0)*f3+(Z(2)^0)*f1*f3+(Z(2)^0)*f1*f4+(Z(2)^0)*f2*f3+(Z(2)^0)*f2*f4+(
-    Z(2)^0)*f3*f4+(Z(2)^0)*f1*f3*f4 ]
+    0)*f2*f3*f4+(Z(2)^0)*f1*f2*f3*f4, (Z(2)^0)*f1+(Z(2)^0)*f2+(Z(2)^0)*f3+(
+    Z(2)^0)*f4+(Z(2)^0)*f1*f3+(Z(2)^0)*f1*f4+(Z(2)^0)*f3*f4+(Z(2)^
+    0)*f1*f3*f4+(Z(2)^0)*f2*f3*f4 ]
 ]]>
 </Example>
 

--- a/doc/funct.xml
+++ b/doc/funct.xml
@@ -765,10 +765,10 @@ true
 gap> KG := GroupRing( GF( 2 ), ElementaryAbelianGroup( 4 ) );
 <algebra-with-one over GF(2), with 2 generators>
 gap> WeightedBasis( KG );
-rec(
-  weightedBasis := [ (Z(2)^0)*<identity> of ...+(Z(2)^0)*f2,
-      (Z(2)^0)*<identity> of ...+(Z(2)^0)*f1,
-      (Z(2)^0)*<identity> of ...+(Z(2)^0)*f1+(Z(2)^0)*f2+(Z(2)^0)*f1*f2 ],
+rec( 
+  weightedBasis := [ (Z(2)^0)*<identity> of ...+(Z(2)^0)*f1, 
+      (Z(2)^0)*<identity> of ...+(Z(2)^0)*f2, 
+      (Z(2)^0)*<identity> of ...+(Z(2)^0)*f1+(Z(2)^0)*f2+(Z(2)^0)*f1*f2 ], 
   weights := [ 1, 1, 2 ] )
 ]]>
 </Example>
@@ -948,7 +948,7 @@ gap> KG := GroupRing( GF( 2 ), DihedralGroup( 16 ) );
 gap> V := NormalizedUnitGroup( KG );
 <group of size 32768 with 15 generators>
 gap> u := GeneratorsOfGroup( V )[4];
-(Z(2)^0)*f1+(Z(2)^0)*f2+(Z(2)^0)*f1*f2  
+(Z(2)^0)*f3  
 ]]>
 </Example>
 
@@ -1043,7 +1043,7 @@ true
 gap> t := NaturalBijectionToNormalizedUnitGroup(KG);;
 gap> w := GeneratorsOfGroup(W)[4];;
 gap> w^t;
-(Z(2)^0)*f1+(Z(2)^0)*f2+(Z(2)^0)*f1*f2    
+(Z(2)^0)*f3    
 gap> GeneratorsOfGroup( W )[4]^t = GeneratorsOfGroup( V )[4];
 true     
 ]]>
@@ -1079,11 +1079,11 @@ gap> V:=PcNormalizedUnitGroup( KG );
 <pc group of size 32768 with 15 generators>
 gap> ucs := UpperCentralSeries( V );;
 gap> f := Embedding( G, V );
-[ f1, f2, f3, f4 ] -> [ f2, f1, f3, f7 ]
+[ f1, f2, f3, f4 ] -> [ f1, f2, f4, f8 ]
 gap> G1 := Image( f, G ); 
-Group([ f2, f1, f3, f7 ])
+Group([ f1, f2, f4, f8 ])
 gap> H := Intersection( ucs[2], G1 ); # compute intersection in V(KG)
-Group([ f3, f7, f3*f7 ])
+Group([ f4, f8, f4*f8 ])
 gap> T:=PreImage( f, H );             # find its preimage in G
 Group([ f3, f4, f3*f4 ])
 gap> IdGroup( T ); 
@@ -1113,7 +1113,7 @@ gap> U := Units( KG );
 #I  LAGUNA package: Computing the unit group ...
 <group of size 32768 with 15 generators>
 gap> GeneratorsOfGroup( U )[5]; # now elements of U are already in KG
-(Z(2)^0)*f2+(Z(2)^0)*f3+(Z(2)^0)*f2*f3
+(Z(2)^0)*f1+(Z(2)^0)*f3+(Z(2)^0)*f1*f3
 gap> FH := GroupRing( GF(3), SmallGroup(27,3) );
 <algebra-with-one over GF(3), with 3 generators>
 gap> T := Units( FH );
@@ -1333,7 +1333,7 @@ gap> IdGroup( BU );
 gap> V := PcNormalizedUnitGroup( KG );
 <pc group of size 128 with 7 generators>
 gap> BV := BicyclicUnitGroup( V );
-Group([ f5*f6, f6*f7 ])
+Group([ f5*f6, f5*f7 ])
 gap> IdGroup( BV );
 [ 4, 2 ]
 gap> Image( NaturalBijectionToPcNormalizedUnitGroup( KG ), BU ) = BV;
@@ -1512,11 +1512,11 @@ Sym( [ 1 .. 3 ] )
 gap> t := NaturalBijectionToLieAlgebra( FG );; 
 #I  LAGUNA package: Constructing Lie algebra ...
 gap> a := Random( FG );
-(Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,3,2)+(Z(2)^0)*(1,3)
+(Z(2)^0)*()+(Z(2)^0)*(2,3)+(Z(2)^0)*(1,2)+(Z(2)^0)*(1,2,3)
 gap> a * a;                     # product in the associative algebra
-(Z(2)^0)*()+(Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,3,2)
+(Z(2)^0)*()+(Z(2)^0)*(2,3)+(Z(2)^0)*(1,2)+(Z(2)^0)*(1,2,3)
 gap> b := a^t;
-LieObject( (Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,3,2)+(Z(2)^0)*(1,3) )
+LieObject( (Z(2)^0)*()+(Z(2)^0)*(2,3)+(Z(2)^0)*(1,2)+(Z(2)^0)*(1,2,3) )
 gap> b * b; # product in the Lie algebra (commutator) - must be zero!
 LieObject( <zero> of ... )
 ]]>

--- a/lib/laguna.gi
+++ b/lib/laguna.gi
@@ -659,7 +659,7 @@ InstallMethod( WeightedBasis,
     [ IsPModularGroupAlgebra ],
     0,
     function(KG)
-        local G, gens, jb, jw, i, k, wb, wbe, c, emb, weight, weights;
+        local G, gens, jb, jw, i, k, wb, wbe, c, emb, weight, weights, pos;
      
         Info(LAGInfo, 2, "LAGInfo: Calculating weighted basis ..." );
          
@@ -690,8 +690,16 @@ InstallMethod( WeightedBasis,
                 Add( wb, wbe );
                 Add( weights, weight );
             od;
-                 
+
+            # Order elements of the weighted basis by their weights.
+            # Then fix the ordering of elements of the same weight
             SortParallel( weights, wb );
+            for k in [ 1 .. Maximum( weights) ] do
+              pos := Positions(weights,k);
+              if Length(pos) > 1 then
+                wb{pos}:=AsSSortedList(wb{pos});
+              fi;
+            od;
                  
             Info(LAGInfo, 2, "LAGInfo: Weighted basis finished !" );
                  

--- a/tst/laguna02.tst
+++ b/tst/laguna02.tst
@@ -134,8 +134,8 @@ MappingByFunction( <group of size 32768 with 15 generators>, <pc group of size\
 gap> Image(t) = W;
 true
 gap> List( AsList( G ), x -> ( x^Embedding( G, KG ) )^t );
-[ <identity> of ..., f2, f1, f3, f7, f1*f2*f3, f2*f3, f2*f7, f1*f3, f1*f7,
-  f3*f7, f1*f2*f7, f1*f2*f3*f7, f2*f3*f7, f1*f3*f7, f1*f2 ]
+[ <identity> of ..., f1, f2, f4, f8, f1*f2, f1*f4, f1*f8, f2*f4, f2*f8, 
+  f4*f8, f1*f2*f4, f1*f2*f8, f1*f4*f8, f2*f4*f8, f1*f2*f4*f8 ]
 
 # laguna/doc/example.xml:254-260
 
@@ -143,47 +143,46 @@ gap> f := NaturalBijectionToNormalizedUnitGroup( KG );;
 gap> Image(f) = V;
 true
 
-# laguna/doc/example.xml:265-277
+# laguna/doc/example.xml:265-276
 
 gap> cc := ConjugacyClasses( W );;
 gap> Length( cc );
 848
 gap> Representative( cc[ Length( cc ) ] );
-f1*f2*f4*f6*f12*f15
+f1*f2*f3*f6*f10*f13
 gap> last^f;
-(Z(2)^0)*<identity> of ...+(Z(2)^0)*f2+(Z(2)^0)*f4+(Z(2)^0)*f1*f2+(Z(2)^
-0)*f1*f3+(Z(2)^0)*f1*f4+(Z(2)^0)*f2*f3+(Z(2)^0)*f2*f4+(Z(2)^0)*f3*f4+(Z(2)^
-0)*f1*f2*f3+(Z(2)^0)*f1*f3*f4
+(Z(2)^0)*<identity> of ...+(Z(2)^0)*f1*f2+(Z(2)^0)*f1*f3+(Z(2)^0)*f1*f4+(Z(2)^
+0)*f2*f3+(Z(2)^0)*f1*f2*f3+(Z(2)^0)*f1*f3*f4
 
-# laguna/doc/example.xml:283-292
+# laguna/doc/example.xml:282-291
 
 gap> LowerCentralSeries( W );
-[ <pc group of size 32768 with 15 generators>,
-  Group([ f3, f5*f8*f10*f12*f13*f14*f15, f6*f8*f12*f14*f15, f7, f9*f12,
-      f10*f14, f11*f13, f13*f14, f14*f15 ]),
-  Group([ f7, f9*f12, f10*f15, f11*f15, f13*f15, f14*f15 ]),
-  Group([ f11*f15, f13*f15, f14*f15 ]), Group([ <identity> of ... ]) ]
+[ <pc group of size 32768 with 15 generators>, 
+  Group([ f4*f8, f5*f7*f11*f13*f15, f6*f7*f9*f11*f13*f14*f15, f8, f9*f13, 
+      f10*f11, f12*f13, f13*f15, f14*f15 ]), 
+  Group([ f8, f9*f15, f10*f11, f12*f15, f13*f15, f14*f15 ]), 
+  Group([ f12*f15, f13*f15, f14*f15 ]), Group([ <identity> of ... ]) ]
 
-# laguna/doc/example.xml:301-320
+# laguna/doc/example.xml:300-319
 
 gap> C := Centre( W );;
 gap> m := MinimalGeneratingSet( C );
-[ f7*f13*f14*f15, f13*f14*f15, f7*f11*f14*f15, f15, f3*f5*f14 ]
+[ f8*f13*f14*f15, f13*f14*f15, f8*f12*f14*f15, f15, f4*f6*f8*f13 ]
 gap> List( m, g -> g^f );
 [ (Z(2)^0)*<identity> of ...+(Z(2)^0)*f3+(Z(2)^0)*f1*f2+(Z(2)^0)*f3*f4+(Z(2)^
-    0)*f1*f2*f3+(Z(2)^0)*f1*f2*f4+(Z(2)^0)*f1*f2*f3*f4,
+    0)*f1*f2*f3+(Z(2)^0)*f1*f2*f4+(Z(2)^0)*f1*f2*f3*f4, 
   (Z(2)^0)*f3+(Z(2)^0)*f4+(Z(2)^0)*f1*f2+(Z(2)^0)*f3*f4+(Z(2)^0)*f1*f2*f3+(
     Z(2)^0)*f1*f2*f4+(Z(2)^0)*f1*f2*f3*f4, (Z(2)^0)*<identity> of ...+(Z(2)^
-    0)*f2+(Z(2)^0)*f3+(Z(2)^0)*f1*f2+(Z(2)^0)*f2*f3+(Z(2)^0)*f2*f4+(Z(2)^
-    0)*f3*f4+(Z(2)^0)*f1*f2*f3+(Z(2)^0)*f1*f2*f4+(Z(2)^0)*f2*f3*f4+(Z(2)^
+    0)*f1+(Z(2)^0)*f3+(Z(2)^0)*f1*f2+(Z(2)^0)*f1*f3+(Z(2)^0)*f1*f4+(Z(2)^
+    0)*f3*f4+(Z(2)^0)*f1*f2*f3+(Z(2)^0)*f1*f2*f4+(Z(2)^0)*f1*f3*f4+(Z(2)^
     0)*f1*f2*f3*f4, (Z(2)^0)*f1+(Z(2)^0)*f2+(Z(2)^0)*f3+(Z(2)^0)*f4+(Z(2)^
     0)*f1*f2+(Z(2)^0)*f1*f3+(Z(2)^0)*f1*f4+(Z(2)^0)*f2*f3+(Z(2)^0)*f2*f4+(
     Z(2)^0)*f3*f4+(Z(2)^0)*f1*f2*f3+(Z(2)^0)*f1*f2*f4+(Z(2)^0)*f1*f3*f4+(Z(2)^
-    0)*f2*f3*f4+(Z(2)^0)*f1*f2*f3*f4, (Z(2)^0)*<identity> of ...+(Z(2)^0)*f1+(
-    Z(2)^0)*f3+(Z(2)^0)*f1*f3+(Z(2)^0)*f1*f4+(Z(2)^0)*f2*f3+(Z(2)^0)*f2*f4+(
-    Z(2)^0)*f3*f4+(Z(2)^0)*f1*f3*f4 ]
+    0)*f2*f3*f4+(Z(2)^0)*f1*f2*f3*f4, (Z(2)^0)*f1+(Z(2)^0)*f2+(Z(2)^0)*f3+(
+    Z(2)^0)*f4+(Z(2)^0)*f1*f3+(Z(2)^0)*f1*f4+(Z(2)^0)*f3*f4+(Z(2)^
+    0)*f1*f3*f4+(Z(2)^0)*f2*f3*f4 ]
 
-# laguna/doc/example.xml:326-350
+# laguna/doc/example.xml:325-349
 
 gap> L := LieAlgebra( KG );
 #I  LAGUNA package: Constructing Lie algebra ...

--- a/tst/laguna04.tst
+++ b/tst/laguna04.tst
@@ -219,10 +219,10 @@ true
 gap> KG := GroupRing( GF( 2 ), ElementaryAbelianGroup( 4 ) );
 <algebra-with-one over GF(2), with 2 generators>
 gap> WeightedBasis( KG );
-rec(
-  weightedBasis := [ (Z(2)^0)*<identity> of ...+(Z(2)^0)*f2,
-      (Z(2)^0)*<identity> of ...+(Z(2)^0)*f1,
-      (Z(2)^0)*<identity> of ...+(Z(2)^0)*f1+(Z(2)^0)*f2+(Z(2)^0)*f1*f2 ],
+rec( 
+  weightedBasis := [ (Z(2)^0)*<identity> of ...+(Z(2)^0)*f1, 
+      (Z(2)^0)*<identity> of ...+(Z(2)^0)*f2, 
+      (Z(2)^0)*<identity> of ...+(Z(2)^0)*f1+(Z(2)^0)*f2+(Z(2)^0)*f1*f2 ], 
   weights := [ 1, 1, 2 ] )
 
 # laguna/doc/funct.xml:794-807
@@ -286,7 +286,7 @@ gap> KG := GroupRing( GF( 2 ), DihedralGroup( 16 ) );
 gap> V := NormalizedUnitGroup( KG );
 <group of size 32768 with 15 generators>
 gap> u := GeneratorsOfGroup( V )[4];
-(Z(2)^0)*f1+(Z(2)^0)*f2+(Z(2)^0)*f1*f2  
+(Z(2)^0)*f3  
 
 # laguna/doc/funct.xml:973-980
 
@@ -311,7 +311,7 @@ true
 gap> t := NaturalBijectionToNormalizedUnitGroup(KG);;
 gap> w := GeneratorsOfGroup(W)[4];;
 gap> w^t;
-(Z(2)^0)*f1+(Z(2)^0)*f2+(Z(2)^0)*f1*f2    
+(Z(2)^0)*f3    
 gap> GeneratorsOfGroup( W )[4]^t = GeneratorsOfGroup( V )[4];
 true     
 
@@ -325,11 +325,11 @@ gap> V:=PcNormalizedUnitGroup( KG );
 <pc group of size 32768 with 15 generators>
 gap> ucs := UpperCentralSeries( V );;
 gap> f := Embedding( G, V );
-[ f1, f2, f3, f4 ] -> [ f2, f1, f3, f7 ]
+[ f1, f2, f3, f4 ] -> [ f1, f2, f4, f8 ]
 gap> G1 := Image( f, G ); 
-Group([ f2, f1, f3, f7 ])
+Group([ f1, f2, f4, f8 ])
 gap> H := Intersection( ucs[2], G1 ); # compute intersection in V(KG)
-Group([ f3, f7, f3*f7 ])
+Group([ f4, f8, f4*f8 ])
 gap> T:=PreImage( f, H );             # find its preimage in G
 Group([ f3, f4, f3*f4 ])
 gap> IdGroup( T ); 
@@ -341,7 +341,7 @@ gap> U := Units( KG );
 #I  LAGUNA package: Computing the unit group ...
 <group of size 32768 with 15 generators>
 gap> GeneratorsOfGroup( U )[5]; # now elements of U are already in KG
-(Z(2)^0)*f2+(Z(2)^0)*f3+(Z(2)^0)*f2*f3
+(Z(2)^0)*f1+(Z(2)^0)*f3+(Z(2)^0)*f1*f3
 gap> FH := GroupRing( GF(3), SmallGroup(27,3) );
 <algebra-with-one over GF(3), with 3 generators>
 gap> T := Units( FH );
@@ -431,7 +431,7 @@ gap> IdGroup( BU );
 gap> V := PcNormalizedUnitGroup( KG );
 <pc group of size 128 with 7 generators>
 gap> BV := BicyclicUnitGroup( V );
-Group([ f5*f6, f6*f7 ])
+Group([ f5*f6, f5*f7 ])
 gap> IdGroup( BV );
 [ 4, 2 ]
 gap> Image( NaturalBijectionToPcNormalizedUnitGroup( KG ), BU ) = BV;
@@ -494,11 +494,11 @@ Sym( [ 1 .. 3 ] )
 gap> t := NaturalBijectionToLieAlgebra( FG );; 
 #I  LAGUNA package: Constructing Lie algebra ...
 gap> a := Random( FG );
-(Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,3,2)+(Z(2)^0)*(1,3)
+(Z(2)^0)*()+(Z(2)^0)*(2,3)+(Z(2)^0)*(1,2)+(Z(2)^0)*(1,2,3)
 gap> a * a;                     # product in the associative algebra
-(Z(2)^0)*()+(Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,3,2)
+(Z(2)^0)*()+(Z(2)^0)*(2,3)+(Z(2)^0)*(1,2)+(Z(2)^0)*(1,2,3)
 gap> b := a^t;
-LieObject( (Z(2)^0)*(1,2,3)+(Z(2)^0)*(1,3,2)+(Z(2)^0)*(1,3) )
+LieObject( (Z(2)^0)*()+(Z(2)^0)*(2,3)+(Z(2)^0)*(1,2)+(Z(2)^0)*(1,2,3) )
 gap> b * b; # product in the Lie algebra (commutator) - must be zero!
 LieObject( <zero> of ... )
 


### PR DESCRIPTION
Now after sorting elements of the weighted basis by their weights,
elements of the same weight will be sorted (w.r.t. `<`). This will
ensure that their order does not rely on the treatment of elements
of the same weight by the sorting algorithm.