### PR TITLE
Add a bunch of trivial implications

### DIFF
--- a/lib/laguna.gd
+++ b/lib/laguna.gd
@@ -35,6 +35,7 @@ DeclareInfoClass("LAGInfo");
 ##  will be determined automatically for every group ring, created by
 ##  the function `GroupRing'
 DeclareProperty("IsGroupAlgebra", IsGroupRing);
+InstallTrueMethod(IsGroupRing, IsGroupAlgebra);
 
 
 #############################################################################
@@ -46,6 +47,7 @@ DeclareProperty("IsGroupAlgebra", IsGroupRing);
 ##  will be determined automatically for every group ring, created by
 ##  the function `GroupRing'
 DeclareProperty("IsFModularGroupAlgebra", IsGroupAlgebra);
+InstallTrueMethod(IsGroupAlgebra, IsFModularGroupAlgebra);
 
 
 #############################################################################
@@ -56,6 +58,7 @@ DeclareProperty("IsFModularGroupAlgebra", IsGroupAlgebra);
 ##  This property will be determined automatically for every group ring, 
 ##  created by the function `GroupRing'
 DeclareProperty("IsPModularGroupAlgebra", IsFModularGroupAlgebra);
+InstallTrueMethod(IsGroupAlgebra, IsPModularGroupAlgebra);
 
 
 #############################################################################
@@ -259,6 +262,7 @@ DeclareAttribute("AugmentationIdealOfDerivedSubgroupNilpotencyIndex",
 #P  IsGroupOfUnitsOfMagmaRing( <U> )
 ##  
 DeclareProperty("IsGroupOfUnitsOfMagmaRing", IsGroup);
+InstallTrueMethod(IsGroup, IsGroupOfUnitsOfMagmaRing);
 
 
 #############################################################################


### PR DESCRIPTION
This makes various "hidden" implications created by DeclareProperty
explicit, thus fixing a bunch of warnings that show up if one starts
the upcoming GAP 4.11 with the `-N` command line option, and then
loads this package.

For some information on the background of this, see also
<https://github.com/gap-system/gap/issues/1649> and
<https://github.com/gap-system/gap/issues/2336>