### PR TITLE
Turn some properties into categories, fix bug

### DIFF
--- a/lib/laguna.gd
+++ b/lib/laguna.gd
@@ -269,14 +269,14 @@ InstallTrueMethod(IsGroup, IsGroupOfUnitsOfMagmaRing);
 ##
 #P  IsUnitGroupOfGroupRing( <U> )
 ##  
-DeclareProperty("IsUnitGroupOfGroupRing", IsGroupOfUnitsOfMagmaRing);
+DeclareCategory("IsUnitGroupOfGroupRing", IsGroupOfUnitsOfMagmaRing);
 
 
 #############################################################################
 ##
 #P  IsNormalizedUnitGroupOfGroupRing( <U> )
 ##  
-DeclareProperty("IsNormalizedUnitGroupOfGroupRing", IsGroupOfUnitsOfMagmaRing);
+DeclareCategory("IsNormalizedUnitGroupOfGroupRing", IsGroupOfUnitsOfMagmaRing);
 
 
 #############################################################################

--- a/lib/laguna.gi
+++ b/lib/laguna.gi
@@ -999,7 +999,7 @@ InstallMethod( NormalizedUnitGroup,
     else
       U := Group( List ( WeightedBasis(KG).weightedBasis, x -> One(KG)+x ) );
       SetIsGroupOfUnitsOfMagmaRing(U,true);
-      SetIsNormalizedUnitGroupOfGroupRing(U,true);
+      SetFilterObj(U, IsNormalizedUnitGroupOfGroupRing);
       SetIsCommutative(U, IsCommutative(UnderlyingMagma(KG)));
       SetIsFinite(U, true);
       SetSize(U, Size(LeftActingDomain(KG))^(Size(UnderlyingMagma(KG))-1));
@@ -1104,7 +1104,7 @@ InstallMethod( PcNormalizedUnitGroup,
 
       U:=GroupByRwsNC(coll); # before we used U:=PcGroupFpGroup( f/rels );
       SetIsGroupOfUnitsOfMagmaRing(U,false);
-      SetIsNormalizedUnitGroupOfGroupRing(U,true);
+      SetFilterObj(U, IsNormalizedUnitGroupOfGroupRing);
       SetIsPGroup(U, true);
       SetPrimePGroup(U, p);
       SetUnderlyingGroupRing(U,KG);   
@@ -1217,7 +1217,7 @@ InstallMethod( Units,
           U:=DirectProduct( K, NormalizedUnitGroup(KG) );
       fi;
       SetIsGroupOfUnitsOfMagmaRing(U,true);
-      SetIsUnitGroupOfGroupRing(U,true);
+      SetFilterObj(U, IsUnitGroupOfGroupRing);
       SetIsCommutative(U, IsCommutative(UnderlyingMagma(KG)));
       SetIsFinite(U, true);
       SetSize( U, Size(Units(LeftActingDomain(KG))) * 
@@ -1250,7 +1250,7 @@ InstallMethod( PcUnits,
           U:=DirectProduct( K, PcNormalizedUnitGroup(KG) );
       fi;
       SetIsGroupOfUnitsOfMagmaRing(U,false);
-      SetIsUnitGroupOfGroupRing(U,true);
+      SetFilterObj(U, IsUnitGroupOfGroupRing);
       SetUnderlyingGroupRing(U,KG);
       return U;
     fi;  
@@ -1345,7 +1345,7 @@ InstallMethod( Random,
         x:=Random(KG);
       until IsUnit(KG,x);
       return One(KG) + x - Augmentation( x ) * One(KG);
-    elif IsUnitGroupOfGroupRing then
+    elif IsUnitGroupOfGroupRing(U) then
       KG:=UnderlyingGroupRing( U );
       repeat
         x:=Random(KG);


### PR DESCRIPTION
There was a bug where `if IsUnitGroupOfGroupRing then` was written
instead of `if IsUnitGroupOfGroupRing(U) then`. However, after making
that fix, I realized that there are no methods installed for
`IsUnitGroupOfGroupRing`, ever. And indeed, thinking about it, I don't
believe it would make sense to do so, this filter indicates something
about how a group was constructed, and in general this can't be tested
post-hoc by a method. Thus, it seems sensible to turn change it from
a property to a category.

Perhaps for `IsNormalizedUnitGroupOfGroupRing` this would be possible,
but for now there is no method for it either, so I also change it to
a category.

Beware that this latter change will break unitlib; but a trivial change
there can remedy this.


Let me emphasis that I am not 100% this is "the right way", so let's discuss it a bit first?