### PR TITLE
fix faulty line terminators in BibTeX data

### DIFF
--- a/doc/manual.bib
+++ b/doc/manual.bib
@@ -1,1 +1,230 @@
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%W  manual.bib             LAGUNA documentation              Victor Bovdi%W                                                    Alexander Konovalov%W                                                     Richard Rossmanith%W                                                         Csaba Scheider%%%%  manual.bib - BibTeX database file of LAGUNA references@incollection {Bov97,    AUTHOR = {Bovdi, A.},     TITLE = {Generators of the units of the modular group algebra of a              finite {$p$}-group}, BOOKTITLE = {Methods in ring theory (Levico Terme, 1997)},    SERIES = {Lecture Notes in Pure and Appl. Math.},    VOLUME = {198},     PAGES = {49--62}, PUBLISHER = {Dekker},   ADDRESS = {New York},      YEAR = {1998},   MRCLASS = {16U60 (16S34)},  MRNUMBER = {MR1767969 (2001f:16061)},MRREVIEWER = {Alexander Zimmermann},}						    }@article{Bov98,    AUTHOR = {Bovdi, A.},     TITLE = {The group of units of a group algebra of characteristic {$p$}},   JOURNAL = {Publ. Math. Debrecen},  FJOURNAL = {Publicationes Mathematicae Debrecen},    VOLUME = {52},      YEAR = {1998},    NUMBER = {1-2},     PAGES = {193--244},      ISSN = {0033-3883},     CODEN = {PUMAAR},   MRCLASS = {16U60 (16S34)},  MRNUMBER = {MR1603359 (99b:16051)},MRREVIEWER = {Sudarshan K. Sehgal},}@article {CS,    AUTHOR = {Catino, F. and Spinelli, E.},     TITLE = {Lie nilpotent group algebras and upper {L}ie codimension              subgroups},   JOURNAL = {Comm. Algebra},  FJOURNAL = {Communications in Algebra},    VOLUME = {34},      YEAR = {2006},    NUMBER = {10},     PAGES = {3859--3873},      ISSN = {0092-7872},     CODEN = {COALDM},   MRCLASS = {16S34 (17Bxx)},  MRNUMBER = {MR2262389},}@article {Du,    AUTHOR = {Du, X. K.},     TITLE = {The centers of a radical ring},   JOURNAL = {Canad. Math. Bull.},  FJOURNAL = {Canadian Mathematical Bulletin. Bulletin Canadien de              Math\'ematiques},    VOLUME = {35},      YEAR = {1992},    NUMBER = {2},     PAGES = {174-179},      ISSN = {0008-4395},     CODEN = {CMBUA3},   MRCLASS = {16N20 (17B60)},  MRNUMBER = {MR1165165 (93d:16023)},MRREVIEWER = {Stefan Veldsman},}@article {JePaSe96,    AUTHOR = {Jespers, E. and Parmenter, M. M. and Sehgal, S. K.},     TITLE = {Central units of integral group rings of nilpotent groups},   JOURNAL = {Proc. Amer. Math. Soc.},  FJOURNAL = {Proceedings of the American Mathematical Society},    VOLUME = {124},      YEAR = {1996},    NUMBER = {4},     PAGES = {1007--1012},      ISSN = {0002-9939},     CODEN = {PAMYAR},   MRCLASS = {16U60 (20C05 20C07)},  MRNUMBER = {MR1328353 (96g:16044)},MRREVIEWER = {Adalbert Bovdi},}@incollection {LR86,    AUTHOR = {Levin, F. and Rosenberger, G.},     TITLE = {Lie metabelian group rings}, BOOKTITLE = {Group and semigroup rings (Johannesburg, 1985)},    SERIES = {North-Holland Math. Stud.},    VOLUME = {126},     PAGES = {153--161}, PUBLISHER = {North-Holland},   ADDRESS = {Amsterdam},      YEAR = {1986},   MRCLASS = {20C07 (16A27)},  MRNUMBER = {MR860058 (87m:20024)},MRREVIEWER = {B. Hartley},}	@article {PPS73,    AUTHOR = {Passi, I. B. S. and Passman, D. S. and Sehgal, S. K.},     TITLE = {Lie solvable group rings},   JOURNAL = {Canad. J. Math.},  FJOURNAL = {Canadian Journal of Mathematics. Journal Canadien de              Math\'ematiques},    VOLUME = {25},      YEAR = {1973},     PAGES = {748--757},      ISSN = {0008-414X},   MRCLASS = {20C05},  MRNUMBER = {MR0325746 (48 \#4092)},MRREVIEWER = {A. Dress},}@phdthesis{Ros97,    AUTHOR = {Rossmanith, R.},     TITLE = {Centre-by-metabelian group algebras},    SCHOOL = {Friedrich-Schiller-Universit{\accent127a}t Jena},      YEAR = {1997},}@article {Ros00,    AUTHOR = {Rossmanith, R.},     TITLE = {Lie centre-by-metabelian group algebras in even              characteristic. {I}, {II}},   JOURNAL = {Israel J. Math.},  FJOURNAL = {Israel Journal of Mathematics},    VOLUME = {115},      YEAR = {2000},     PAGES = {51--75, 77--99},      ISSN = {0021-2172},     CODEN = {ISJMAP},   MRCLASS = {16S34 (17B30)},  MRNUMBER = {MR1749673 (2000m:16038)},MRREVIEWER = {Donald S. Passman},}@article {Ross,    AUTHOR = {Rossmanith, R.},     TITLE = {Lie centre-by-metabelian group algebras over commutative              rings},   JOURNAL = {J. Algebra},  FJOURNAL = {Journal of Algebra},    VOLUME = {251},      YEAR = {2002},    NUMBER = {2},     PAGES = {503--508},      ISSN = {0021-8693},     CODEN = {JALGA4},   MRCLASS = {16S34 (20C05 20C07)},  MRNUMBER = {MR1917380 (2003h:16042)},MRREVIEWER = {Michael Dokuchaev},}@book {Sims,    AUTHOR = {Sims, C. C.},     TITLE = {Computation with finitely presented groups},    SERIES = {Encyclopedia of Mathematics and its Applications},    VOLUME = {48}, PUBLISHER = {Cambridge University Press},   ADDRESS = {Cambridge},      YEAR = {1994},     PAGES = {xiii+604},      ISBN = {0-521-43213-8},   MRCLASS = {20F05 (20-02 68Q40 68Q42)},  MRNUMBER = {MR1267733 (95f:20053)},MRREVIEWER = {Friedrich Otto},}@book {HB,    AUTHOR = {Huppert, B. and Blackburn, N.},     TITLE = {Finite groups. {II}},    SERIES = {Grundlehren der Mathematischen Wissenschaften [Fundamental              Principles of Mathematical Sciences]},    VOLUME = {242},      NOTE = {,              AMD, 44}, PUBLISHER = {Springer-Verlag},   ADDRESS = {Berlin},      YEAR = {1982},     PAGES = {xiii+531},      ISBN = {3-540-10632-4},   MRCLASS = {20-02 (20Dxx)},  MRNUMBER = {MR650245 (84i:20001a)},}@article {Shalev91,    AUTHOR = {Shalev, A.},     TITLE = {Lie dimension subgroups, {L}ie nilpotency indices, and the              exponent of the group of normalized units},   JOURNAL = {J. London Math. Soc. (2)},  FJOURNAL = {Journal of the London Mathematical Society. Second Series},    VOLUME = {43},      YEAR = {1991},    NUMBER = {1},     PAGES = {23--36},      ISSN = {0024-6107},     CODEN = {JLMSAK},   MRCLASS = {20C05 (16S34 16U60)},  MRNUMBER = {MR1099083 (92b:20009)},MRREVIEWER = {Burkhard K{\"u}lshammer},}@article {Wursthorn,    AUTHOR = {Wursthorn, M.},     TITLE = {Isomorphisms of modular group algebras: an algorithm and its              application to groups of order {$2\sp 6$}},   JOURNAL = {J. Symbolic Comput.},  FJOURNAL = {Journal of Symbolic Computation},    VOLUME = {15},      YEAR = {1993},    NUMBER = {2},     PAGES = {211--227},      ISSN = {0747-7171},   MRCLASS = {20C05 (20C40 68Q40)},  MRNUMBER = {MR1218760 (94h:20008)},MRREVIEWER = {Wolfgang Lempken},}%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%E
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%
+%W  manual.bib             LAGUNA documentation              Victor Bovdi
+%W                                                    Alexander Konovalov
+%W                                                     Richard Rossmanith
+%W                                                         Csaba Scheider
+%%
+%%  manual.bib - BibTeX database file of LAGUNA references
+
+
+@incollection {Bov97,
+    AUTHOR = {Bovdi, A.},
+     TITLE = {Generators of the units of the modular group algebra of a
+              finite {$p$}-group},
+ BOOKTITLE = {Methods in ring theory (Levico Terme, 1997)},
+    SERIES = {Lecture Notes in Pure and Appl. Math.},
+    VOLUME = {198},
+     PAGES = {49--62},
+ PUBLISHER = {Dekker},
+   ADDRESS = {New York},
+      YEAR = {1998},
+   MRCLASS = {16U60 (16S34)},
+  MRNUMBER = {MR1767969 (2001f:16061)},
+MRREVIEWER = {Alexander Zimmermann},
+}
+						    }
+
+@article{Bov98,
+    AUTHOR = {Bovdi, A.},
+     TITLE = {The group of units of a group algebra of characteristic {$p$}},
+   JOURNAL = {Publ. Math. Debrecen},
+  FJOURNAL = {Publicationes Mathematicae Debrecen},
+    VOLUME = {52},
+      YEAR = {1998},
+    NUMBER = {1-2},
+     PAGES = {193--244},
+      ISSN = {0033-3883},
+     CODEN = {PUMAAR},
+   MRCLASS = {16U60 (16S34)},
+  MRNUMBER = {MR1603359 (99b:16051)},
+MRREVIEWER = {Sudarshan K. Sehgal},
+}
+
+@article {CS,
+    AUTHOR = {Catino, F. and Spinelli, E.},
+     TITLE = {Lie nilpotent group algebras and upper {L}ie codimension
+              subgroups},
+   JOURNAL = {Comm. Algebra},
+  FJOURNAL = {Communications in Algebra},
+    VOLUME = {34},
+      YEAR = {2006},
+    NUMBER = {10},
+     PAGES = {3859--3873},
+      ISSN = {0092-7872},
+     CODEN = {COALDM},
+   MRCLASS = {16S34 (17Bxx)},
+  MRNUMBER = {MR2262389},
+}
+
+@article {Du,
+    AUTHOR = {Du, X. K.},
+     TITLE = {The centers of a radical ring},
+   JOURNAL = {Canad. Math. Bull.},
+  FJOURNAL = {Canadian Mathematical Bulletin. Bulletin Canadien de
+              Math\'ematiques},
+    VOLUME = {35},
+      YEAR = {1992},
+    NUMBER = {2},
+     PAGES = {174-179},
+      ISSN = {0008-4395},
+     CODEN = {CMBUA3},
+   MRCLASS = {16N20 (17B60)},
+  MRNUMBER = {MR1165165 (93d:16023)},
+MRREVIEWER = {Stefan Veldsman},
+}
+
+@article {JePaSe96,
+    AUTHOR = {Jespers, E. and Parmenter, M. M. and Sehgal, S. K.},
+     TITLE = {Central units of integral group rings of nilpotent groups},
+   JOURNAL = {Proc. Amer. Math. Soc.},
+  FJOURNAL = {Proceedings of the American Mathematical Society},
+    VOLUME = {124},
+      YEAR = {1996},
+    NUMBER = {4},
+     PAGES = {1007--1012},
+      ISSN = {0002-9939},
+     CODEN = {PAMYAR},
+   MRCLASS = {16U60 (20C05 20C07)},
+  MRNUMBER = {MR1328353 (96g:16044)},
+MRREVIEWER = {Adalbert Bovdi},
+}
+
+@incollection {LR86,
+    AUTHOR = {Levin, F. and Rosenberger, G.},
+     TITLE = {Lie metabelian group rings},
+ BOOKTITLE = {Group and semigroup rings (Johannesburg, 1985)},
+    SERIES = {North-Holland Math. Stud.},
+    VOLUME = {126},
+     PAGES = {153--161},
+ PUBLISHER = {North-Holland},
+   ADDRESS = {Amsterdam},
+      YEAR = {1986},
+   MRCLASS = {20C07 (16A27)},
+  MRNUMBER = {MR860058 (87m:20024)},
+MRREVIEWER = {B. Hartley},
+}
+
+@article {PPS73,
+    AUTHOR = {Passi, I. B. S. and Passman, D. S. and Sehgal, S. K.},
+     TITLE = {Lie solvable group rings},
+   JOURNAL = {Canad. J. Math.},
+  FJOURNAL = {Canadian Journal of Mathematics. Journal Canadien de
+              Math\'ematiques},
+    VOLUME = {25},
+      YEAR = {1973},
+     PAGES = {748--757},
+      ISSN = {0008-414X},
+   MRCLASS = {20C05},
+  MRNUMBER = {MR0325746 (48 \#4092)},
+MRREVIEWER = {A. Dress},
+}
+
+@phdthesis{Ros97,
+    AUTHOR = {Rossmanith, R.},
+     TITLE = {Centre-by-metabelian group algebras},
+    SCHOOL = {Friedrich-Schiller-Universit{\accent127a}t Jena},
+      YEAR = {1997},
+}
+
+@article {Ros00,
+    AUTHOR = {Rossmanith, R.},
+     TITLE = {Lie centre-by-metabelian group algebras in even
+              characteristic. {I}, {II}},
+   JOURNAL = {Israel J. Math.},
+  FJOURNAL = {Israel Journal of Mathematics},
+    VOLUME = {115},
+      YEAR = {2000},
+     PAGES = {51--75, 77--99},
+      ISSN = {0021-2172},
+     CODEN = {ISJMAP},
+   MRCLASS = {16S34 (17B30)},
+  MRNUMBER = {MR1749673 (2000m:16038)},
+MRREVIEWER = {Donald S. Passman},
+}
+
+@article {Ross,
+    AUTHOR = {Rossmanith, R.},
+     TITLE = {Lie centre-by-metabelian group algebras over commutative
+              rings},
+   JOURNAL = {J. Algebra},
+  FJOURNAL = {Journal of Algebra},
+    VOLUME = {251},
+      YEAR = {2002},
+    NUMBER = {2},
+     PAGES = {503--508},
+      ISSN = {0021-8693},
+     CODEN = {JALGA4},
+   MRCLASS = {16S34 (20C05 20C07)},
+  MRNUMBER = {MR1917380 (2003h:16042)},
+MRREVIEWER = {Michael Dokuchaev},
+}
+
+@book {Sims,
+    AUTHOR = {Sims, C. C.},
+     TITLE = {Computation with finitely presented groups},
+    SERIES = {Encyclopedia of Mathematics and its Applications},
+    VOLUME = {48},
+ PUBLISHER = {Cambridge University Press},
+   ADDRESS = {Cambridge},
+      YEAR = {1994},
+     PAGES = {xiii+604},
+      ISBN = {0-521-43213-8},
+   MRCLASS = {20F05 (20-02 68Q40 68Q42)},
+  MRNUMBER = {MR1267733 (95f:20053)},
+MRREVIEWER = {Friedrich Otto},
+}
+
+@book {HB,
+    AUTHOR = {Huppert, B. and Blackburn, N.},
+     TITLE = {Finite groups. {II}},
+    SERIES = {Grundlehren der Mathematischen Wissenschaften [Fundamental
+              Principles of Mathematical Sciences]},
+    VOLUME = {242},
+      NOTE = {,
+              AMD, 44},
+ PUBLISHER = {Springer-Verlag},
+   ADDRESS = {Berlin},
+      YEAR = {1982},
+     PAGES = {xiii+531},
+      ISBN = {3-540-10632-4},
+   MRCLASS = {20-02 (20Dxx)},
+  MRNUMBER = {MR650245 (84i:20001a)},
+}
+
+@article {Shalev91,
+    AUTHOR = {Shalev, A.},
+     TITLE = {Lie dimension subgroups, {L}ie nilpotency indices, and the
+              exponent of the group of normalized units},
+   JOURNAL = {J. London Math. Soc. (2)},
+  FJOURNAL = {Journal of the London Mathematical Society. Second Series},
+    VOLUME = {43},
+      YEAR = {1991},
+    NUMBER = {1},
+     PAGES = {23--36},
+      ISSN = {0024-6107},
+     CODEN = {JLMSAK},
+   MRCLASS = {20C05 (16S34 16U60)},
+  MRNUMBER = {MR1099083 (92b:20009)},
+MRREVIEWER = {Burkhard K{\"u}lshammer},
+}
+
+@article {Wursthorn,
+    AUTHOR = {Wursthorn, M.},
+     TITLE = {Isomorphisms of modular group algebras: an algorithm and its
+              application to groups of order {$2\sp 6$}},
+   JOURNAL = {J. Symbolic Comput.},
+  FJOURNAL = {Journal of Symbolic Computation},
+    VOLUME = {15},
+      YEAR = {1993},
+    NUMBER = {2},
+     PAGES = {211--227},
+      ISSN = {0747-7171},
+   MRCLASS = {20C05 (20C40 68Q40)},
+  MRNUMBER = {MR1218760 (94h:20008)},
+MRREVIEWER = {Wolfgang Lempken},
+}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%
+%E


### PR DESCRIPTION
 This patch replaces the CR line terminators '\r' of the BibTeX data
 `doc/manual.bib` with new line terminators '\n'.